### PR TITLE
some checks for existing values

### DIFF
--- a/libraries/Gas.php
+++ b/libraries/Gas.php
@@ -1299,7 +1299,9 @@ class Gas {
  				break;
  			
  			default:
- 				return $this->_set_fields[$name];
+ 				if (isset($this->_set_fields[$name])) {
+ 					return $this->_set_fields[$name];
+ 				}
  				break;
  		}
  	}

--- a/libraries/Gas.php
+++ b/libraries/Gas.php
@@ -849,7 +849,7 @@ class Gas {
 
 		foreach($original as $origin)
 		{
-			if($this->_set_fields[$origin]) $stripped[$origin] = $this->_set_fields[$origin];
+			if(isset($this->_set_fields[$origin])) $stripped[$origin] = $this->_set_fields[$origin];
 		}
 
 		$this->_set_fields = $stripped;


### PR DESCRIPTION
1. When accessing a value of an object directly (i.e. $user->name) prevent an error if the name property is not yet set.
2. When updating an existing object (_locked_table) check if a value exists (isset) rather than if it evaluates to FALSE when deciding which values to update. 
   Otherwise a property that is equal to FALSE (i.e. the value zero) will not be included in the UPDATE statement.
