### PR TITLE
Crash where "pdodriver" not defined in config

### DIFF
--- a/third_party/gas/classes/core.php
+++ b/third_party/gas/classes/core.php
@@ -2472,7 +2472,7 @@ class Core {
 			return static::$$dbal_component;
 
 		}
-		elseif ($name == 'insert_id' && static::$db->pdodriver == 'pgsql')
+		elseif ($name == 'insert_id' && isset(static::$db->pdodriver) && static::$db->pdodriver == 'pgsql')
 		{
 			return static::$db->conn_id->lastInsertId();
 		}


### PR DESCRIPTION
Hi Toopay,
In the new config files pdodriver is not necessarily set, this gives an error when saving.  See http://codeigniter.com/forums/viewthread/213348/P60/#992337  

I've added a check for isset(static::$db->pdodriver)  which fixes this issue for me. 

Thanks - keep up the good work! 
