### PR TITLE
Time Stamps are Stored in 12-hr Format

### DIFF
--- a/third_party/gas/classes/core.php
+++ b/third_party/gas/classes/core.php
@@ -440,12 +440,12 @@ class Core {
 						if ($gas->empty)
 						{
 							$ts_field = str_replace(array('[',']'), array('',''), $ts_field);
-							$gas->$ts_field = ($field == 'ts_fields') ? date('Y-m-d h:i:s') : time();
+							$gas->$ts_field = ($field == 'ts_fields') ? date('Y-m-d H:i:s') : time();
 						}
 					}
 					else
 					{
-						$gas->$ts_field = ($field == 'ts_fields') ? date('Y-m-d h:i:s') : time();
+						$gas->$ts_field = ($field == 'ts_fields') ? date('Y-m-d H:i:s') : time();
 					}
 				}
 			}


### PR DESCRIPTION
The built in time stamp generation is storing times in 12 hr format (i.e., 1 PM stored as 1:00:00). It should be stored in 24 hr format (i.e., 1 PM stored as 13:00:00).

This is a fix for that issue.
